### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/qhash.js
+++ b/qhash.js
@@ -87,7 +87,7 @@ module.exports = {
         var path = dottedPath.split('.');
         for (var item=target, i=0; i<path.length-1; i++) {
             var field = path[i];
-            if (!item[field] || typeof item[field] !== 'object') item[field] = {};
+            if (!item[field] || typeof item[field] !== 'object' || isPrototypePolluted(field)) item[field] = {};
             item = item[field];
         }
         return item[path[path.length-1]] = value;
@@ -178,4 +178,9 @@ function indexOfCharCode( str, ch ) {
 // a hash object is not instanceof any class
 function isHash(o) {
     return o && typeof o === 'object' && o.constructor == Object;
+}
+
+// Blacklist certain keys to prevent Prototype Pollution
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }


### PR DESCRIPTION
### :bar_chart: Metadata *

`qhash` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-qhash

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('qhash')

console.log(`Before: ${{}.polluted}`)
set({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i qhash # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104936522-a7506480-59d2-11eb-8dc9-cdc2cf65b211.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
