### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/qhash.js
+++ b/qhash.js
@@ -7,6 +7,25 @@
 
 'use strict';
 
+var ILLEGAL_KEYS = new Set(['constructor', 'prototype', '__proto__']);
+
+function isIllegalKey(key) {
+  return ILLEGAL_KEYS.has(key);
+}
+
+function isProtoPath(path) {
+  return Array.isArray(path) 
+    ? path.some(isIllegalKey) 
+    : typeof path === "string" 
+      ? isIllegalKey(path)
+      : false;   
+}
+
+function disallowProtoPath(path) {
+  if (isProtoPath(path)) {
+    throw new Error("Unsafe path encountered: " + path)
+  }
+}
 
 module.exports = {
     /*
@@ -87,6 +106,7 @@ module.exports = {
         var path = dottedPath.split('.');
         for (var item=target, i=0; i<path.length-1; i++) {
             var field = path[i];
+            disallowProtoPath(field);
             if (!item[field] || typeof item[field] !== 'object') item[field] = {};
             item = item[field];
         }

--- a/qhash.js
+++ b/qhash.js
@@ -41,6 +41,8 @@ module.exports = {
         if (typeof source !== 'object') return merge(this, target, source);
 
         for (var key in source) {
+            disallowProtoPath(key)
+
             if (noOverwrite && (key in target)) {
                 if (isHash(target[key]) && isHash(source[key])) {
                     target[key] = merge(target[key], source[key], true);

--- a/test-qhash.js
+++ b/test-qhash.js
@@ -86,6 +86,12 @@ describe ('qhash', function() {
             done();
         })
 
+        it('should throw when trying to overwrite prototype methods', function (done) {
+          var target = {};
+          assert.throws(() => merge(target, JSON.parse('{"__proto__": { "polluted": true }}')));
+          done();
+        })
+
         describe ('options', function() {
             it ('noOverwrite should not alter existing properties', function(done) {
                 var target = qhash.merge({a:1, b:2}, {b:3, c:4}, true);
@@ -132,6 +138,12 @@ describe ('qhash', function() {
             assert.deepEqual(target, {a:{s:3}, b:{s:2}});
 
             done();
+        })
+
+        it('should throw when trying to overwrite prototype methods', function (done) {
+          var target = {};
+          assert.throws(() => mmerge(target, JSON.parse('{"__proto__": { "polluted": true }}')));
+          done();
         })
     })
 
@@ -204,7 +216,7 @@ describe ('qhash', function() {
                 [ {}, 'b', [1], {b:[1]} ],
                 [ {a:1}, 'b', 2, {a:1, b:2} ],
                 [ {b:1}, 'a', 2, {b:1, a:2} ],
-                [ {a:[]}, 'a.0', 1, {a:{'0':1}} ],
+                [ {a:{}}, 'a.0', 1, {a:{'0':1}} ],
                 [ {a:[]}, 'a.0', 1, {a:[1]} ],          // TODO: is object, not array!
             ];
             testSetDataset(dataset);
@@ -257,6 +269,12 @@ describe ('qhash', function() {
             target.set('a.b', 3);
             assert.deepEqual(target.a, {b:3});
             done();
+        })
+
+        it('should throw when trying to overwrite prototype methods', function (done) {
+          var target = {};
+          assert.throws(() => set(target, '__proto__.polluted', true));
+          done();
         })
     })
 


### PR DESCRIPTION
### 📊 Metadata *

`qhash ` is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-qhash

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as __proto__, constructor and prototype. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


1. Create the following PoC file:

```
// poc.js
const { set } = require('qhash')

console.log('Before: ' + {}.polluted)
set({}, '__proto__.polluted', true)
console.log('After: ' + {}.polluted)
```

Execute the following commands in the terminal:

```
npm i qhash # install vulnerable package
node poc.js # run the PoC
```

Check the output:

```
Before: undefined
After: true
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106352305-f9b14f80-6307-11eb-84b6-fcab1ba17f62.png)


After:
![image](https://user-images.githubusercontent.com/64132745/106352251-709a1880-6307-11eb-8204-189da59ce514.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106355282-e361be80-631c-11eb-80c8-410dc4a8107c.png)

After the fix functionality is unaffected

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1701
